### PR TITLE
Change missed renames and deconflict docker container names with dj core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,20 @@ volumes:
   postgres_data: {}
   redis_data: {}
 
+networks:
+  djqs-network:
+    driver: bridge
+  dj_dj-network:
+    external: true
+
 services:
   djqs:
-    container_name: dj
+    container_name: djqs
+    stdin_open: true
+    tty: true
+    networks:
+      - dj_dj-network
+      - djqs-network
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
@@ -15,35 +26,41 @@ services:
     ports:
       - "8001:8001"
     depends_on:
-      - db_migration
-      - postgres_examples
-      - redis
+      - db-migration-djqs
+      - postgres-examples-djqs
+      - redis-djqs
 
-  celery:
-    container_name: celery
+  celery-djqs:
+    container_name: celery-djqs
+    networks:
+      - djqs-network
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
     volumes:
       - .:/code
     depends_on:
-      - dj
+      - djqs
     command: celery -A djqs.api.queries.celery worker --loglevel=info
 
-  watchdog:
-    container_name: watchdog
+  watchdog-djqs:
+    container_name: watchdog-djqs
+    networks:
+      - djqs-network
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
     volumes:
       - .:/code
     depends_on:
-      - dj
+      - djqs
     command: djqs compile --reload
     restart: on-failure
 
-  db_migration:
-    container_name: db_migration
+  db-migration-djqs:
+    container_name: db-migration
+    networks:
+      - djqs-network
     environment:
       - DOTENV_FILE=.docker-env/.env
     build: .
@@ -52,17 +69,21 @@ services:
     command: alembic upgrade head
     restart: on-failure
 
-  redis:
+  redis-djqs:
     image: redis:latest
     container_name: query_broker
+    networks:
+      - djqs-network
     restart: unless-stopped
     ports:
       - "6379:6379"
     volumes:
       - redis_data:/data
 
-  postgres_examples:
-    container_name: postgres_examples
+  postgres-examples-djqs:
+    container_name: postgres-examples-djqs
+    networks:
+      - djqs-network
     image: postgres:latest
     volumes:
       - ./examples/docker/postgres_init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -75,4 +96,4 @@ services:
       - POSTGRES_USER=username
       - POSTGRES_DB=examples
     ports:
-      - "5433:5432"
+      - "5434:5432"

--- a/examples/configs/databases/postgres.yaml
+++ b/examples/configs/databases/postgres.yaml
@@ -1,5 +1,5 @@
 description: A Postgres database
-URI: postgresql://username:FoolishPassword@postgres_examples:5432/examples
+URI: postgresql://username:FoolishPassword@postgres-examples-djqs:5432/examples
 extra_params:
   connect_args:
     sslmode: prefer

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
 
 [metadata]
-name = dj
+name = djqs
 description = Add a short description here!
 author = Beto Dealmeida
 author_email = roberto@dealmeida.net
@@ -158,6 +158,6 @@ exclude =
 # PyScaffold's parameters when the project was created.
 # This will be used when updating. Do not change!
 version = 4.1
-package = dj
+package = djqs
 extensions =
     pre_commit


### PR DESCRIPTION
### Summary

Change `dj` to `djqs` in a few places that were missed.

This also makes some updates to the docker compose file:
- Deconflicts the container names with the `dj` docker compose setup
  - i.e. rename `watchdog` to `watchdog-djqs`
- Adds a `djqs-network`
  - Instead of relying on the default network docker compose gives us, this explicitly creates a named `djqs-network` (will help separate docker compose environments to interact with eachother)
- Ad a hook into a core dj docker compose setup using `dj_dj-network`
  - This is so that we can add an explicit `dj-network` to the core DJ server, and then this would be able to hook into there so the containers can talk to each other. The idea here is the we would be able to do `docker compose up` to start the DJ core server, then do `docker compose up` to start the DJQS server and they would be able to talk to each other.

### Test Plan

Ran `make check` and `make test`.

- [ ] PR has an associated issue: #1 
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan


N/A
