### PR TITLE
Change dj core network name to dj_core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 networks:
   djqs-network:
     driver: bridge
-  dj_dj-network:
+  dj_core:
     external: true
 
 services:
@@ -16,7 +16,7 @@ services:
     stdin_open: true
     tty: true
     networks:
-      - dj_dj-network
+      - dj_core
       - djqs-network
     environment:
       - DOTENV_FILE=.docker-env/.env


### PR DESCRIPTION
### Summary

This changes the external dj network to `dj_core`.

### Test Plan

`make check` and `make test`. Confirmed that this allows interacting with a running dj docker compose setup.

- [x] PR has an associated issue: #1 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
