### PR TITLE
Rename redis container to deconflict with dj core

### DIFF
--- a/.docker-env/.env-cockroachdb
+++ b/.docker-env/.env-cockroachdb
@@ -2,5 +2,5 @@ NAME="Example DJ query server backed by CockroachDB"
 DESCRIPTION="A simple DJ query server running in Docker backed by CockroachDB"
 INDEX=cockroachdb://root:@cockroachdb_metadata:26257/djqs?sslmode=disable
 REPOSITORY=examples/cockroachdb/configs
-REDIS_CACHE=redis://query_broker:6379/0
-CELERY_BROKER=redis://query_broker:6379/1
+REDIS_CACHE=redis://query-broker-djqs:6379/0
+CELERY_BROKER=redis://query-broker-djqs:6379/1

--- a/.docker-env/.env-postgres
+++ b/.docker-env/.env-postgres
@@ -2,5 +2,5 @@ NAME="Example DJ query server backed by Postgres"
 DESCRIPTION="A simple DJ query server running in Docker backed by Postgres"
 INDEX=postgresql://username:FoolishPassword@postgres_metadata:5432/dj
 REPOSITORY=examples/configs
-REDIS_CACHE=redis://query_broker:6379/0
-CELERY_BROKER=redis://query_broker:6379/1
+REDIS_CACHE=redis://query-broker-djqs:6379/0
+CELERY_BROKER=redis://query-broker-djqs:6379/1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
 
   redis-djqs:
     image: redis:latest
-    container_name: query_broker
+    container_name: query-broker-djqs
     networks:
       - djqs-network
     restart: unless-stopped


### PR DESCRIPTION
### Summary

This renames the `query_broker` redis container to `query-broker-djqs` to deconflict with the dj core docker compose which causes a "container name query_broker already exists" error when trying to run both.

### Test Plan

Ran `docker compose up` for both dj and djqs and ensured there are no naming conflicts.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
