### PR TITLE
Clear up README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Catalogs can be created using the :code:`POST /catalogs/` endpoint.
       -H 'accept: application/json' \
       -H 'Content-Type: application/json' \
       -d '{
-      "name": "public"
+      "name": "djdb"
     }'
 
 Creating Engines
@@ -47,7 +47,7 @@ Engines can be created using the :code:`POST /engines/` endpoint.
       -d '{
       "name": "postgres",
       "version": "15.2",
-      "uri": "postgresql://dj:dj@postgres-roads:5432/roads"
+      "uri": "postgresql://dj:dj@postgres-roads:5432/djdb"
     }'
 
 Engines can be attached to existing catalogs using the :code:`POST /catalogs/{name}/engines/` endpoint.
@@ -55,7 +55,7 @@ Engines can be attached to existing catalogs using the :code:`POST /catalogs/{na
 .. code-block:: sh
 
     curl -X 'POST' \
-      'http://localhost:8001/catalogs/public/engines/' \
+      'http://localhost:8001/catalogs/djdb/engines/' \
       -H 'accept: application/json' \
       -H 'Content-Type: application/json' \
       -d '[
@@ -77,7 +77,7 @@ Queries can be submitted to DJQS for a specified catalog and engine.
       -H 'accept: application/json' \
       -H 'Content-Type: application/json' \
       -d '{
-      "catalog_name": "public",
+      "catalog_name": "djdb",
       "engine_name": "postgres",
       "engine_version": "15.2",
       "submitted_query": "SELECT * from roads.repair_orders",
@@ -93,7 +93,7 @@ Async queries can be submitted as well.
       -H 'accept: application/json' \
       -H 'Content-Type: application/json' \
       -d '{
-      "catalog_name": "public",
+      "catalog_name": "djdb",
       "engine_name": "postgres",
       "engine_version": "15.2",
       "submitted_query": "SELECT * from roads.repair_orders",
@@ -105,7 +105,7 @@ Async queries can be submitted as well.
 .. code-block:: json
 
     {
-      "catalog_name": "public",
+      "catalog_name": "djdb",
       "engine_name": "postgres",
       "engine_version": "15.2",
       "id": "<QUERY ID HERE>",
@@ -136,7 +136,7 @@ once it's completed.
 .. code-block:: json
 
     {
-      "catalog_name": "public",
+      "catalog_name": "djdb",
       "engine_name": "postgres",
       "engine_version": "15.2",
       "id": "$QUERY_ID",
@@ -169,7 +169,7 @@ If running a [reflection service](https://github.com/DataJunction/djrs), that se
 .. code-block:: sh
 
     curl -X 'GET' \
-      'http://localhost:8001/table/public.roads.repair_orders/columns/' \
+      'http://localhost:8001/table/djdb.roads.repair_orders/columns/?engine=postgres&engine_version=15.2' \
       -H 'accept: application/json'
 
 *response*
@@ -177,7 +177,7 @@ If running a [reflection service](https://github.com/DataJunction/djrs), that se
 .. code-block:: json
 
     {
-      "name": "public.roads.repair_orders",
+      "name": "djdb.roads.repair_orders",
       "columns": [
         {
           "name": "repair_order_id",
@@ -209,11 +209,3 @@ If running a [reflection service](https://github.com/DataJunction/djrs), that se
         }
       ]
     }
-
-You can optionally include a specific engine and engine version to use for reflection.
-
-.. code-block:: sh
-
-    curl -X 'GET' \
-      'http://localhost:8001/table/public.roads.repair_orders/columns/?engine=postgres&engine_version=15.2' \
-      -H 'accept: application/json'

--- a/djqs/config.py
+++ b/djqs/config.py
@@ -22,7 +22,7 @@ class Settings(BaseSettings):  # pylint: disable=too-few-public-methods
     index: str = "sqlite:///djqs.db?check_same_thread=False"
 
     # The default engine to use for reflection
-    default_reflection_engine: str = "sqlalchemy"
+    default_reflection_engine: str = "default"
 
     # The default engine version to use for reflection
     default_reflection_engine_version: str = ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     restart: on-failure
 
   postgres-roads:
-    container_name: postgres_roads
+    container_name: postgres-roads
     networks:
       - djqs-network
     image: postgres:latest

--- a/docker/postgres_init.roads.sql
+++ b/docker/postgres_init.roads.sql
@@ -1,3 +1,8 @@
+DROP DATABASE IF EXISTS djdb;
+CREATE DATABASE djdb;
+
+\connect djdb;
+
 CREATE SCHEMA IF NOT EXISTS roads;
 
 DROP TABLE IF EXISTS roads.municipality_municipality_type;

--- a/tests/api/table_test.py
+++ b/tests/api/table_test.py
@@ -10,7 +10,7 @@ def test_table_columns(client: TestClient, mocker):
     """
     response = client.post(
         "/engines/",
-        json={"name": "sqlalchemy", "version": "", "uri": "sqlite://"},
+        json={"name": "default", "version": "", "uri": "sqlite://"},
     )
     assert response.status_code == 201
     columns = [


### PR DESCRIPTION
### Summary

In the current README examples, it uses the public schema in postgres. This updates the postgres container to create the `roads` database in a `djdb` database. The `djdb` postgres database is then registered in `djqs` as a catalog that has a `postgres` engine with `uri=postgresql://dj:dj@postgres-roads:5432/djdb`. The examples can all be ran end to end after a clean `docker compose up`.

### Test Plan

N/A

- [x] PR has an associated issue: #1 
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
