### PR TITLE
Add support for getting table columns via Spark

### DIFF
--- a/djqs/api/helpers.py
+++ b/djqs/api/helpers.py
@@ -9,6 +9,7 @@ from sqlalchemy import inspect
 from sqlalchemy.exc import NoResultFound, NoSuchTableError, OperationalError
 from sqlmodel import Session, create_engine, select
 
+from djqs.engine import describe_table_via_spark, get_spark_session
 from djqs.exceptions import DJException
 from djqs.models.catalog import Catalog
 from djqs.models.engine import Engine
@@ -57,6 +58,14 @@ def get_columns(
     """
     if not uri:
         raise DJException("Cannot retrieve columns without a uri")
+
+    if uri.startswith("spark://"):
+        spark = get_spark_session()
+        return describe_table_via_spark(
+            spark,
+            schema,
+            table,
+        )
 
     engine = create_engine(uri, **extra_params)
     try:

--- a/djqs/api/tables.py
+++ b/djqs/api/tables.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
 from djqs.api.helpers import get_columns, get_engine
+from djqs.engine import describe_table_via_spark, get_spark_session
 from djqs.exceptions import DJInvalidTableRef
 from djqs.models.table import TableInfo
 from djqs.utils import get_session, get_settings

--- a/djqs/api/tables.py
+++ b/djqs/api/tables.py
@@ -7,7 +7,6 @@ from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
 from djqs.api.helpers import get_columns, get_engine
-from djqs.engine import describe_table_via_spark, get_spark_session
 from djqs.exceptions import DJInvalidTableRef
 from djqs.models.table import TableInfo
 from djqs.utils import get_session, get_settings

--- a/djqs/engine.py
+++ b/djqs/engine.py
@@ -149,6 +149,19 @@ def run_spark_query(
     return output
 
 
+def describe_table_via_spark(
+    spark: SparkSession,
+    schema: str,
+    table: str,
+):
+    """
+    Gets the column schemas.
+    """
+    schema_df = spark.sql(f"DESCRIBE TABLE {schema}.{table};")
+    rows = schema_df.rdd.map(tuple).collect()
+    return [{"name": row[0], "type": row[1]} for row in rows]
+
+
 def process_query(
     session: Session,
     settings: Settings,

--- a/djqs/engine.py
+++ b/djqs/engine.py
@@ -4,7 +4,7 @@ Query related functions.
 
 import logging
 from datetime import datetime, timezone
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import sqlparse
 from pyspark.sql import SparkSession  # pylint: disable=import-error
@@ -151,7 +151,7 @@ def run_spark_query(
 
 def describe_table_via_spark(
     spark: SparkSession,
-    schema: str,
+    schema: Optional[str],
     table: str,
 ):
     """

--- a/djqs/engine.py
+++ b/djqs/engine.py
@@ -157,7 +157,8 @@ def describe_table_via_spark(
     """
     Gets the column schemas.
     """
-    schema_df = spark.sql(f"DESCRIBE TABLE {schema}.{table};")
+    schema_ = f"{schema}." if schema else ""
+    schema_df = spark.sql(f"DESCRIBE TABLE {schema_}{table};")
     rows = schema_df.rdd.map(tuple).collect()
     return [{"name": row[0], "type": row[1]} for row in rows]
 

--- a/djqs/models/query.py
+++ b/djqs/models/query.py
@@ -68,7 +68,7 @@ class ColumnMetadata(SQLModel):
     """
 
     name: str
-    type: ColumnType
+    type: str
 
 
 class StatementResults(SQLModel):

--- a/djqs/models/query.py
+++ b/djqs/models/query.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql.schema import Column as SqlaColumn
 from sqlalchemy_utils import UUIDType
 from sqlmodel import Field, SQLModel
 
-from djqs.typing import ColumnType, QueryState, Row
+from djqs.typing import QueryState, Row
 
 
 class BaseQuery(SQLModel):

--- a/tests/api/queries_test.py
+++ b/tests/api/queries_test.py
@@ -549,7 +549,7 @@ def test_spark_describe_tables(spark) -> None:
     """
     Test that using spark to describe tables works
     """
-    column_metadata = describe_table_via_spark(spark, "roads", "contractors")
+    column_metadata = describe_table_via_spark(spark, None, "contractors")
     assert column_metadata == [
         {"name": "contractor_id", "type": "int"},
         {"name": "company_name", "type": "string"},

--- a/tests/api/queries_test.py
+++ b/tests/api/queries_test.py
@@ -13,7 +13,7 @@ from pytest_mock import MockerFixture
 from sqlmodel import Session
 
 from djqs.config import Settings
-from djqs.engine import process_query
+from djqs.engine import describe_table_via_spark, process_query
 from djqs.models.catalog import Catalog
 from djqs.models.engine import Engine
 from djqs.models.query import (
@@ -542,6 +542,25 @@ def test_spark_fixture_show_tables(spark) -> None:
         ("", "repair_type", True),
         ("", "us_region", True),
         ("", "us_states", True),
+    ]
+
+
+def test_spark_describe_tables(spark) -> None:
+    """
+    Test that using spark to describe tables works
+    """
+    column_metadata = describe_table_via_spark(spark, "roads", "contractors")
+    assert column_metadata == [
+        {"name": "contractor_id", "type": "int"},
+        {"name": "company_name", "type": "string"},
+        {"name": "contact_name", "type": "string"},
+        {"name": "contact_title", "type": "string"},
+        {"name": "address", "type": "string"},
+        {"name": "city", "type": "string"},
+        {"name": "state", "type": "string"},
+        {"name": "postal_code", "type": "string"},
+        {"name": "country", "type": "string"},
+        {"name": "phone", "type": "string"},
     ]
 
 


### PR DESCRIPTION
### Summary

Adds support for getting table columns via Spark. This just uses `DESCRIBE TABLE` to retrieve the columns and their types. No type conversion is done as we're now using fully-compatible Spark types on the DJ side.

### Test Plan

Verified it end-to-end with DJ + DJRS + DJQS running.

- [X] PR has an associated issue: https://github.com/DataJunction/djqs/issues/14
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
